### PR TITLE
fix|Update sources path for cluster3

### DIFF
--- a/.github/workflows/flux-local-test.yaml
+++ b/.github/workflows/flux-local-test.yaml
@@ -28,6 +28,6 @@ jobs:
       with:
         enable-helm: true
         enable-kyverno: false
-        sources: cluster=./tests/testdata/cluster3/clusters/cluster3,flux-system,home-ops-kubernetes
+        sources: cluster=./tests/testdata/cluster3/,flux-system,home-ops-kubernetes
         path: ${{ matrix.cluster_path }}
         api-versions: batch/v1/CronJob

--- a/.github/workflows/flux-local-test.yaml
+++ b/.github/workflows/flux-local-test.yaml
@@ -28,6 +28,6 @@ jobs:
       with:
         enable-helm: true
         enable-kyverno: false
-        sources: cluster=tests/testdata/cluster3,flux-system,home-ops-kubernetes
+        sources: cluster=tests/testdata/cluster3/flux-system,flux-system,home-ops-kubernetes
         path: ${{ matrix.cluster_path }}
         api-versions: batch/v1/CronJob

--- a/.github/workflows/flux-local-test.yaml
+++ b/.github/workflows/flux-local-test.yaml
@@ -28,6 +28,6 @@ jobs:
       with:
         enable-helm: true
         enable-kyverno: false
-        sources: cluster=tests/testdata/cluster3/clusters/cluster3/flux-system,flux-system,home-ops-kubernetes
+        sources: cluster=./tests/testdata/cluster3/clusters/cluster3,flux-system,home-ops-kubernetes
         path: ${{ matrix.cluster_path }}
         api-versions: batch/v1/CronJob

--- a/.github/workflows/flux-local-test.yaml
+++ b/.github/workflows/flux-local-test.yaml
@@ -28,6 +28,6 @@ jobs:
       with:
         enable-helm: true
         enable-kyverno: false
-        sources: cluster=tests/testdata/cluster3/flux-system,flux-system,home-ops-kubernetes
+        sources: cluster=tests/testdata/cluster3/clusters/cluster3/flux-system,flux-system,home-ops-kubernetes
         path: ${{ matrix.cluster_path }}
         api-versions: batch/v1/CronJob


### PR DESCRIPTION
Updated the meaning of sources for successful testing.
The input parameter takes the relative path
```bash
  --sources SOURCES     Optional GitRepository or OCIRepository sources to restrict to e.g. `flux-system`. Can include optional map of repository source to relative path e.g. `cluster=./k8s/`
  ```